### PR TITLE
Коригування жанрів у випадку запиту подробиць одного фільму

### DIFF
--- a/src/js/addFilm.js
+++ b/src/js/addFilm.js
@@ -5,7 +5,14 @@ import fetchMovieById from "./fetchMovieById";
 export default function addFilm(storage, film_id) {
   const refs = getRefs();
   let array = [];
-  const film_obj = (localStorage.getItem('trending')) ? JSON.parse(localStorage.getItem('trending')).find(element => element.id === film_id) : fetchMovieById(film_id);
+  let film_obj = {};
+  if (localStorage.getItem(refs.movieKey)) {
+    film_obj = JSON.parse(localStorage.getItem(refs.movieKey)).find(element => element.id === film_id);
+  } else {
+    const fetchedObj = fetchMovieById(film_id);
+    fetchedObj.genre_ids = fetchedObj.genres.map(item => item.id);
+    film_obj = fetchedObj;
+  }
   if (localStorage.getItem(storage)) {
     array = JSON.parse(localStorage.getItem(storage));
   }


### PR DESCRIPTION
При отриманні інформації про фільм з сервера у випадку відсутності у сховищі жанри приходять словами. Поки переробила назад в ідентифікатори для передачі функції зберігання у сховищі бібліотеки. Це на випадок очищення сховища під час додавання до бібліотеки (малоймовірний випадок).