### PR TITLE
Відступ модалки зверху екрана, видалення синього кольору карток

### DIFF
--- a/src/partials/gallery.html
+++ b/src/partials/gallery.html
@@ -12,11 +12,11 @@
   <div class="container main__wrapper">
     <h1 class="visually-hidden">Watch movies online with Filmoteka</h1>
     <ul class="gallery movie__list" data-action="galleryList"></ul>
+    <div id="pagination2" class="tui-pagination"></div>
   </div>
   <button type="button" class="btn-up">
     <svg class="icon-up" width="12" height="12">
       <use href="./images/icons.svg#icon-arrow-up"></use>
     </svg>
   </button>
-  <div id="pagination2" class="tui-pagination"></div>
 </section>

--- a/src/sass/components/_film-modal.scss
+++ b/src/sass/components/_film-modal.scss
@@ -29,16 +29,17 @@
 
   @media screen and (min-width: 480px) {
     width: 80vw;
-    margin: 20px auto;
   }
 
   @media screen and (min-width: $tablet) {
     width: 704px;
+    margin: 219px auto 0px;
     padding: 40px 36px;
   }
 
   @media screen and (min-width: $desktop) {
     width: 814px;
+    margin: 151px auto 0px;
     padding-left: 16px;
     padding-right: 16px;
   }

--- a/src/sass/components/_trending.scss
+++ b/src/sass/components/_trending.scss
@@ -93,10 +93,6 @@
   color: $hover-orange;
 }
 
-.darkmode--activated .movie__genre {
-  color: #0094f7;
-}
-
 .movie__vote {
   display: inline-block;
   margin-left: 8px;
@@ -116,5 +112,4 @@
 
 .darkmode--activated .movie__vote {
   color: $text-color-white;
-  background-color: #0094f7;
 }


### PR DESCRIPTION
Додавання відступу модалки зверху для планшету та десктопу відповідно до макету, видалення синього кольору рейтингу карток фільмів